### PR TITLE
Fix broken URL for a2dpins image

### DIFF
--- a/_worksheets/arduino/plant-moisture-tweeter.md
+++ b/_worksheets/arduino/plant-moisture-tweeter.md
@@ -49,7 +49,7 @@ Connect the moisture sensor to the other two pins sticking out. It doesn't matte
 
 You can see the pins on the A2D chip better in this picture - the labels are hidden.
 
-![Connecting up an Arduino to a moisture meter for an analogue signal reading]({{ 'a2dpins.jpg' | prepend: page.url }})
+![Connecting up an Arduino to a moisture meter for an analogue signal reading]({{ 'a2dpins.JPG' | prepend: page.url }})
 
 ## Step Two: Monitor the Arduino serial output
 


### PR DESCRIPTION
I noticed one of the images was not displaying. The referenced file is in the folder but with the extension in caps, the URL must be case sensitive even for the file extension so I changed it.